### PR TITLE
Fixing front matter when postmeta contains an object

### DIFF
--- a/markdown-exporter.php
+++ b/markdown-exporter.php
@@ -574,6 +574,11 @@ class Markdown_Exporter {
         $indentation = str_repeat( '  ', $indent );
 
         foreach ( $array as $key => $value ) {
+            if ( is_object( $value ) ) {
+                // Skip meta values that are encoded as complicated objects
+                continue;
+            }
+            
             // Replace spaces with underscores in keys to avoid YAML issues.
             $key = str_replace( ' ', '_', $key );
 


### PR DESCRIPTION
This fixes the issue on my site.  Basically if the postmeta contains an object, it just skips to the next entry in the for loop.  Otherwise it ends up at line 602 where it tries to turn it into YAML -  $this->escape_yaml_string( $value )